### PR TITLE
Use explicit count modifiers

### DIFF
--- a/jsfx.JSON-tmLanguage
+++ b/jsfx.JSON-tmLanguage
@@ -1,4 +1,4 @@
-{ 
+{
 	"name": "JesuSonic FX (EEL2)",
 	"scopeName": "source.jsfx",
 	"fileTypes": [
@@ -32,7 +32,7 @@
 	],
 	"repository": {
 		"contexts":	{
-			"patterns":	[	
+			"patterns":	[
 				{
 					"begin": "^(desc|(in|out)_pin|options)(?=:.+)",
 					"beginCaptures": { "0": { "name": "entity.name.section.jsfx" } },
@@ -224,11 +224,11 @@
 					"endCaptures": { "0": { "name": "meta.nl.jsfx" } },
 					"name": "meta.section.jsfx.function",
 					"patterns":	[
-						{ 
+						{
 							"match": "\\b[a-zA-Z_]+[a-zA-Z0-9_](?=[(])",
 							"name": "entity.name.function.jsfx"
 						},
-						{ 
+						{
 							"begin": "\\b(local|instance)(?=[(])\\b",
 							"beginCaptures": { "0": { "name": "storage.modifier.jsfx" } },
 							"end": "\\z",
@@ -265,7 +265,7 @@
 				{
 					"comment": "ThreeChars Operators",
 					"disabled": "0",
-					"match": "([=]{3})|([!]{1}[=]{2})",
+					"match": "([=]{3})|([!][=]{2})",
 					"name": "keyword.operator.jsfx"
 				},
 				{
@@ -313,7 +313,7 @@
 					"name": "variable.language.jsfx"
 				},
 				{
-					"match": "\\b(spl(?=[(]{1,}))",
+					"match": "\\b(spl(?=[(]+))",
 					"name": "support.function.jsfx"
 				}
 			]
@@ -387,7 +387,7 @@
 		"numerics": {
 			"comment": "Numerical values - 154 or 187.7 or 0x548 or $x548 or $-4 (for bit masks)",
 			"disabled": "0",
-			"match": "\\b((-?\\d{1,}([.]{1}\\d{1,})?)\\b|\\b([\\$0]{1}x[0123456789ABCDEFabcdef]{1,8})\\b|\\b(\\$(-\\d{1,3})|('.')))\\b",
+			"match": "\\b((-?\\d+([.]\\d+)?)\\b|\\b([\\$0]x[0123456789ABCDEFabcdef]{1,8})\\b|\\b(\\$(-\\d{1,3})|('.')))\\b",
 			"name": "constant.numeric.jsfx"
 		},
 		"strings": {

--- a/jsfx.tmLanguage
+++ b/jsfx.tmLanguage
@@ -238,7 +238,7 @@
 					<key>disabled</key>
 					<string>0</string>
 					<key>match</key>
-					<string>([=]{3})|([!]{1}[=]{2})</string>
+					<string>([=]{3})|([!][=]{2})</string>
 					<key>name</key>
 					<string>keyword.operator.jsfx</string>
 				</dict>
@@ -300,7 +300,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(spl(?=[(]{1,}))</string>
+					<string>\b(spl(?=[(]+))</string>
 					<key>name</key>
 					<string>support.function.jsfx</string>
 				</dict>
@@ -895,7 +895,7 @@
 			<key>disabled</key>
 			<string>0</string>
 			<key>match</key>
-			<string>\b((-?\d{1,}([.]{1}\d{1,})?)\b|\b([\$0]{1}x[0123456789ABCDEFabcdef]{1,8})\b|\b(\$(-\d{1,3})|('.')))\b</string>
+			<string>\b((-?\d+([.]\d+)?)\b|\b([\$0]x[0123456789ABCDEFabcdef]{1,8})\b|\b(\$(-\d{1,3})|('.')))\b</string>
 			<key>name</key>
 			<string>constant.numeric.jsfx</string>
 		</dict>


### PR DESCRIPTION
The construction `{1,}` in regular expressions is only supported by Oniguruma (which is used by TextMate and Sublime Text). However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regular expressions.

This is a known issue that we've been fixing in many grammars. Unfortunately, it doesn't seem to be source of the bug you reporter in github/linguist#2753.

There is also an issue on [line 304](https://github.com/L-EARN/Sublime-JSFX/blob/7e72e8045b68cb5add4dce1dbe3cd2f235189834/jsfx.JSON-tmLanguage#L304). I'm not sure what was the expected behavior, so I left it as is.
