### PR TITLE
Avoid consuming end of lines for sliders

### DIFF
--- a/jsfx.JSON-tmLanguage
+++ b/jsfx.JSON-tmLanguage
@@ -86,16 +86,14 @@
 				{
 					"begin": "^slider\\d{1,2}(?=:)",
 					"beginCaptures": { "0": { "name": "entity.name.section.jsfx" } },
-					"end": "\\n",
-					"endCaptures": { "0": { "name": "meta.nl.jsfx" } },
+					"end": "(?=\\n)",
 					"name": "meta.block.jsfx",
 					"patterns":	[
 						{ "include": "#numerics" },
 						{
 							"begin": ">",
 							"beginCaptures": { "0": { "name": "keyword.operator.jsfx" } },
-							"end": "\\n",
-							"endCaptures": { "0": { "name": "meta.nl.jsfx" } },
+							"end": "(?=\\n)",
 							"name": "meta.section.jsfx.gfx",
 							"patterns":	[ { "include": "#string_unquoted" } ]
 						},


### PR DESCRIPTION
This PR fixes the [issue reported](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2FL-EARN%2FSublime-JSFX%2Fblob%2Feol-instead-of-eos%2Fjsfx.JSON-tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fbelangeo%2Fcookdsp%2Fblob%2Fmaster%2FPobjects_examples%2FPobjects_bp&code=) in github/linguist#2753 with `sliders` lines: [example in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2FSublime-JSFX%2Feol%2Fjsfx.JSON-tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fbelangeo%2Fcookdsp%2Fblob%2Fmaster%2FPobjects_examples%2FPobjects_bp&code=).
